### PR TITLE
Add party to tests

### DIFF
--- a/tests/features/wi-elections.feature.csv
+++ b/tests/features/wi-elections.feature.csv
@@ -120,8 +120,8 @@ filename,party,candidate,county,office,district,ward,votes,total
 ,NP,JOEL WINNIG,Door,Supreme Court,,TOWN OF GIBRALTAR Wards 1 & 2,6,102
 ,NP,DANIEL P. STEFFEN,Polk,"POLK COUNTY CIRCUIT COURT, BRANCH 2",,TOWN OF WEST SWEDEN Wards 1 & 2,13,25
 20110405__wi__general__ward.csv,,,,,,,,
-,NP,"David T. Prosser, Jr.",Manitowoc,Supreme Court,,"CITY OF MANITOWOC Wards 17, 18, 22, 24 - 26, 28 - 30, 32, 34 & 36",306,555
-,NP,Joanne F. Kloppenburg,Racine,Supreme Court,,TOWN OF WATERFORD Wards 1 - 10,573,2183
+,,"David T. Prosser, Jr.",Manitowoc,Supreme Court,,"CITY OF MANITOWOC Wards 17, 18, 22, 24 - 26, 28 - 30, 32, 34 & 36",306,555
+,,Joanne F. Kloppenburg,Racine,Supreme Court,,TOWN OF WATERFORD Wards 1 - 10,573,2183
 ,NP,SANDRA J. MARCUS,Marathon,"MARATHON COUNTY CIRCUIT COURT, BRANCH 5",,VILLAGE OF BIRNAMWOOD Ward 2,5,5
 ,NP,GUY DUTCHER,Waushara,WAUSHARA COUNTY CIRCUIT COURT,,TOWN OF POY SIPPI Ward 1,170,170
 ,NP,PAUL B. HIGGINBOTHAM,Jackson,Court of Appeals,4,VILLAGE OF HIXTON Ward 1,93,93
@@ -146,7 +146,7 @@ filename,party,candidate,county,office,district,ward,votes,total
 20110809__wi__general-recall__ward.csv,,,,,,,,
 ,REP,ROBERT L. COWLES,Brown,State Senate,2,CITY OF DE PERE District 1 Ward 1-3,1057,2016
 ,DEM,NANCY J. NUSBAUM,Outagamie,State Senate,2,VILLAGE OF SHIOCTON Village of Shiocton,86,180
-,REP,SANDRA K. PASCH,Washington,State Senate,8,CITY OF MILWAUKEE Ward 262,0,0
+,DEM,SANDRA K. PASCH,Washington,State Senate,8,CITY OF MILWAUKEE Ward 262,0,0
 ,REP,SHEILA E. HARSDORF,Burnett,State Senate,10,TOWN OF LINCOLN Lincoln Town,60,108
 ,,Scattering,Shawano,State Senate,14,CITY OF MARION Wards 4 - 6,0,5
 ,DEM,JESSICA KING,Winnebago,State Senate,18,CITY OF OMRO Wards 1 - 7,598,1104
@@ -205,20 +205,20 @@ filename,party,candidate,county,office,district,ward,votes,total
 20121204__wi__special__general__ward.csv,,,,,,,,
 ,REP,Paul Farrow,Waukesha,State Senate,33,City of Pewaukee Wards 8-10,274,281
 20130219__wi__primary__ward.csv,,,,,,,,
-,NP,Vince Megna,Grant,Supreme Court,,"TOWN OF SOUTH LANCASTER WARDS 1, 2 & 3",3,19
-,NP,Janet Claire Protasiewicz,Milwaukee,"Milwaukee County Circuit Court, Branch 45",,CITY OF MILWAUKEE WARD 001,32,140
+,IND,Vince Megna,Grant,Supreme Court,,"TOWN OF SOUTH LANCASTER WARDS 1, 2 & 3",3,19
+,IND,Janet Claire Protasiewicz,Milwaukee,"Milwaukee County Circuit Court, Branch 45",,CITY OF MILWAUKEE WARD 001,32,140
 20130219__wi__special__primary__ward.csv,,,,,,,,
 ,REP,Matt Morzy,Waukesha,State Assembly,98,City of Waukesha Ward 4,6,70
 ,REP,Adam Neylon,Waukesha,State Assembly,98,City of Pewaukee Wards 5-7,219,559
 ,REP,Jeanne Tarantino,Waukesha,State Assembly,98,TOWN OF LISBON WARD 3,11,132
 20130402__wi__general__ward.csv,,,,,,,,
-,NP,Tony Evers,Adams,State Superintendent Of Public Instruction,,Town Of Monroe Ward 1,53,94
-,NP,Tony Evers,Columbia,State Superintendent Of Public Instruction,,City Of Wisconsin Dells Ward 1,54,74
-,NP,Don Pridemore,Dane,State Superintendent Of Public Instruction,,City Of Madison Ward 49,12,82
-,NP,Don Pridemore,Wood,State Superintendent Of Public Instruction,,Town Of Seneca Wards 1 -3,55,136
-,NP,Daniel T. Dillon,Rock,"Rock County Circuit Court, Branch 4",,CITY OF BRODHEAD WARDS 7-8,6,6
-,NP,Lisa K. Stark,Ashland,Court of Appeals,3,TOWN OF SHANAGOLDEN Wards 1,22,22
-,NP,Ed Fallone,Langlade,Supreme Court,,TOWN OF AINSWORTH WARD 1,30,100
+,IND,Tony Evers,Adams,State Superintendent Of Public Instruction,,Town Of Monroe Ward 1,53,94
+,IND,Tony Evers,Columbia,State Superintendent Of Public Instruction,,City Of Wisconsin Dells Ward 1,54,74
+,IND,Don Pridemore,Dane,State Superintendent Of Public Instruction,,City Of Madison Ward 49,12,82
+,IND,Don Pridemore,Wood,State Superintendent Of Public Instruction,,Town Of Seneca Wards 1 -3,55,136
+,IND,Daniel T. Dillon,Rock,"Rock County Circuit Court, Branch 4",,CITY OF BRODHEAD WARDS 7-8,6,6
+,IND,Lisa K. Stark,Ashland,Court of Appeals,3,TOWN OF SHANAGOLDEN Wards 1,22,22
+,IND,Ed Fallone,Langlade,Supreme Court,,TOWN OF AINSWORTH WARD 1,30,100
 20130402__wi__special__general__ward.csv,,,,,,,,
 ,REP,Adam Neylon,Waukesha,State Assembly,98,CITY OF WAUKESHA Ward 36,314,315
 ,REP,Adam Neylon,Waukesha,State Assembly,98,"VILLAGE OF SUSSEX Wards 5,6,7",417,419
@@ -233,7 +233,7 @@ filename,party,candidate,county,office,district,ward,votes,total
 20131217__wi__special__general__ward.csv,,,,,,,,
 ,DEM,John R. Hermes,Milwaukee,State Assembly,82,City of Greenfield Ward 20,86,223
 20140218__wi__primary__ward.csv,,,,,,,,
-,NP,Roger M. Hillestad,Dunn,"Dunn County Circuit Court, Branch 1",,TOWN OF RED CEDAR WARD 1-3,11,71
+,IND,Roger M. Hillestad,Dunn,"Dunn County Circuit Court, Branch 1",,TOWN OF RED CEDAR WARD 1-3,11,71
 20140401__wi__general__ward.csv,,,,,,,,
 ,NP,Gary E. Sherman,Waupaca,Court of Appeals,4,TOWN OF HELVETIA Wards 1 & 2,44,44
 ,NP,"Robert A. Kennedy, Jr.",Florence,Florence-Forest County Circuit Court,,TOWN OF FENCE WARD 1,24,46
@@ -312,7 +312,7 @@ filename,party,candidate,county,office,district,ward,votes,total
 ,NP,Lowell E. Holtz,Rock,State Superintendent Of Public Instruction,,CITY OF BRODHEAD Wards 7-8,0,5
 20170404__wi__general__ward.csv,,,,,,,,
 ,NP,Rick Melcher (write-in),Shawano,State Superintendent of Public Instruction,,CITY OF SHAWANO Wards 7-8,1,165
-,NP,Scattering,Dane,Supreme Court,,CITY OF MADISON Ward 40,184,723
+,,Scattering,Dane,Supreme Court,,CITY OF MADISON Ward 40,184,723
 ,NP,Brian K. Hagedorn,Ozaukee,Court of Appeals,2,TOWN OF BELGIUM Ward 1-3,113,113
 ,NP,Guy Dutcher,Waushara,Waushara County Circuit Court,,CITY OF WAUTOMA Wards 1-3,117,117
 20171219__wi__special__primary__ward.csv,,,,,,,,

--- a/tests/features/wi-elections.feature.csv
+++ b/tests/features/wi-elections.feature.csv
@@ -2,20 +2,19 @@ filename,party,candidate,county,office,district,ward,votes,total
 20001107__wi__general__ward.csv,,,,,,,,
 ,REP,Kitty Rhoades,Pierce,State Assembly,30,City of Prescott Wards 1 - 4,1036,1759
 ,LIB,Tim Peterson,Racine,Senate,,Town of Mount Pleasant Wards 7 & 8,8,1851
-20001107__wi__general__ward.csv,,,,,,,,
 ,,Scattering,Lincoln,President,,Town of Bradley Wards 1 - 6,4,1457
 20020910__wi__primary__ward.csv,,,,,,,,
 ,DEM,Dale Moore,Racine,House,1,CITY OF RACINE Ward 30,38,151
 ,REP,Peggy A. Rosenzweig,Milwaukee,State Senate,5,CITY OF MILWAUKEE Ward 286,19,58
 20021105__wi__general__ward.csv,,,,,,,,
-,,Scott McCallum & Margaret A. Farrow,Adams,Governor,,TOWN OF ADAMS Wards 1 & 2,113,428
-,,Peggy A. Lautenschlager,Dodge,Attorney General,,CITY OF MAYVILLE Wards 1 - 7,617,1336
-,,Edward J. Frami,Oneida,Secretary of State,,TOWN OF STELLA,2,196
-,,Paul Aschenbrenner,Vilas,State Treasurer,,TOWN OF LINCOLN Wards 1 - 5,100,996
+,REP,Scott McCallum & Margaret A. Farrow,Adams,Governor,,TOWN OF ADAMS Wards 1 & 2,113,428
+,DEM,Peggy A. Lautenschlager,Dodge,Attorney General,,CITY OF MAYVILLE Wards 1 - 7,617,1336
+,CON,Edward J. Frami,Oneida,Secretary of State,,TOWN OF STELLA,2,196
+,WGR,Paul Aschenbrenner,Vilas,State Treasurer,,TOWN OF LINCOLN Wards 1 - 5,100,996
 ,,Scattering,Green Lake,House,6,"CITY OF BERLIN Wards 1 - 6, 8 - 10",16,1161
-,,Dale W. Schultz,Grant,State Senate,17,TOWN OF LITTLE GRANT,54,70
-,,John H. Ainsworth,Oconto,State Assembly,6,TOWN OF HOW Wards 1 - 3,175,175
-,,Kathleen A. Pakes,Rusk,Rusk County District Attorney,,TOWN OF THORNAPPLE Wards 1 & 2,217,219
+,REP,Dale W. Schultz,Grant,State Senate,17,TOWN OF LITTLE GRANT,54,70
+,REP,John H. Ainsworth,Oconto,State Assembly,6,TOWN OF HOW Wards 1 - 3,175,175
+,DEM,Kathleen A. Pakes,Rusk,Rusk County District Attorney,,TOWN OF THORNAPPLE Wards 1 & 2,217,219
 20041102__wi__general__ward.csv,,,,,,,,
 ,IND,Peter Miguel Camejo & Ralph Nader,Brown,President,,VILLAGE OF HOWARD Wards 1 - 8,27,3767
 ,DEM,Russ Feingold,Outagamie,Senate,,CITY OF APPLETON Ward 22,725,1319
@@ -28,38 +27,37 @@ filename,party,candidate,county,office,district,ward,votes,total
 20060110__wi__special__general__ward.csv,,,,,,,,
 ,REP,Scott Newcomer,Waukesha,State Assembly,33,VILLAGE OF NASHOTAH Wards 1 & 2,75,106
 20060221__wi__primary__ward.csv,,,,,,,,
-,,Karen L. Seifert,Winnebago,"Winnebago County Circuit Court, Branch 4",,VILLAGE OF WINNECONNE Wards 1 - 4,91,128
+,NP,Karen L. Seifert,Winnebago,"Winnebago County Circuit Court, Branch 4",,VILLAGE OF WINNECONNE Wards 1 - 4,91,128
 20060404__wi__general__ward.csv,,,,,,,,
-,,Patrick Crooks,Brown,Supreme Court,,CITY OF GREEN BAY Ward 34,306,311
-,,Margaret J. Vergeront,Columbia,Court of Appeals,4,CITY OF LODI Wards 1 - 4,253,253
+,NP,Patrick Crooks,Brown,Supreme Court,,CITY OF GREEN BAY Ward 34,306,311
+,NP,Margaret J. Vergeront,Columbia,Court of Appeals,4,CITY OF LODI Wards 1 - 4,253,253
 ,,Scattering,Milwaukee,"Milwaukee County Circuit Court, Branch 39",,VILLAGE OF BROWN DEER Wards 1 - 9,2,1523
 20060912__wi__primary__ward.csv,,,,,,,,
 ,CON,Scattering,Rusk,Attorney General,,TOWN OF FLAMBEAU Wards 1 - 3,1,1
 ,DEM,Jim Doyle,Clark,Governor,,TOWN OF BEAVER Wards 1 & 2,19,19
 ,LIB,Scattering,Barron,Lieutenant Governor,,CITY OF CUMBERLAND Wards 1 - 5,1,1
 20061107__wi__general__ward.csv,,,,,,,,
-,,H. Craig Haukaas,Bayfield,Bayfield County District Attorney,,TOWN OF BELL,107,109
-,,Michael LaForest,Monroe,Secretary of State,,TOWN OF WILTON Wards 1 - 3,10,161
-,,"Winston Sephus, Jr.",Chippewa,State Treasurer,,CITY OF BLOOMER Wards 1 - 4,21,1085
-,,Charlie Most,Brown,State Senate,1,VILLAGE OF BELLEVUE Wards 7 - 10,1109,2835
-,,Ben Bourdo,Jefferson,State Assembly,31,CITY OF WHITEWATER Wards 14 & 15,0,2
-,,Robert Gerald Lorge,Buffalo,Senate,,TOWN OF MODENA,33,136
-,,David R. Obey,Ashland,House,7,TOWN OF AGENDA,128,190
+,REP,H. Craig Haukaas,Bayfield,Bayfield County District Attorney,,TOWN OF BELL,107,109
+,WGR,Michael LaForest,Monroe,Secretary of State,,TOWN OF WILTON Wards 1 - 3,10,161
+,WGR,"Winston Sephus, Jr.",Chippewa,State Treasurer,,CITY OF BLOOMER Wards 1 - 4,21,1085
+,DEM,Charlie Most,Brown,State Senate,1,VILLAGE OF BELLEVUE Wards 7 - 10,1109,2835
+,IND,Ben Bourdo,Jefferson,State Assembly,31,CITY OF WHITEWATER Wards 14 & 15,0,2
+,REP,Robert Gerald Lorge,Buffalo,Senate,,TOWN OF MODENA,33,136
+,DEM,David R. Obey,Ashland,House,7,TOWN OF AGENDA,128,190
 20070220__wi__primary__ward.csv,,,,,,,,
-,,Joseph Sommers,Marathon,Supreme Court,,TOWN OF EAU PLEINE,2,24
-,,Kara M. Burgos,La Crosse,"La Crosse County Circuit Court, Branch 4",,VILLAGE OF WEST SALEM Wards 1 - 6,78,400
+,NP,Joseph Sommers,Marathon,Supreme Court,,TOWN OF EAU PLEINE,2,24
+,NP,Kara M. Burgos,La Crosse,"La Crosse County Circuit Court, Branch 4",,VILLAGE OF WEST SALEM Wards 1 - 6,78,400
 20070403__wi__general__ward.csv,,,,,,,,
-,,Linda M. Clifford,Walworth,Supreme Court,,CITY OF WHITEWATER Wards 7 & 8,27,46
+,NP,Linda M. Clifford,Walworth,Supreme Court,,CITY OF WHITEWATER Wards 7 & 8,27,46
 ,,Scattering,Barron,Court Of Appeals,3,TOWN OF STANFOLD,2,138
-,,Thomas G. Grover,Shawano,"Menominee-Shawano County Circuit Court, Branch 2",,TOWN OF ANGELICA Wards 1 - 3,297,297
+,NP,Thomas G. Grover,Shawano,"Menominee-Shawano County Circuit Court, Branch 2",,TOWN OF ANGELICA Wards 1 - 3,297,297
 20080219__wi__primary__ward.csv,,,,,,,,
 ,REP,John McCain,Milwaukee,President,,CITY OF MILWAUKEE Ward 278,54,90
-20080219__wi__primary__ward.csv,,,,,,,,
-,,Ken Sortedahl,St. Croix,"St Croix County Circuit Court, Branch 4",,VILLAGE OF DEER PARK,3,50
+,NP,Ken Sortedahl,St. Croix,"St Croix County Circuit Court, Branch 4",,VILLAGE OF DEER PARK,3,50
 20080401__wi__general__ward.csv,,,,,,,,
-,,James D. Babbitt,Barron,"Barron County Circuit Court, Branch 3",,TOWN OF DALLAS Wards 1 & 2,57,68
-,,Burneatta L. Bridge,Grant,Court Of Appeals,4,TOWN OF CASTLE ROCK,48,48
-,,Louis Butler,Forest,Supreme Court,,TOWN OF POPPLE RIVER,3,18
+,NP,James D. Babbitt,Barron,"Barron County Circuit Court, Branch 3",,TOWN OF DALLAS Wards 1 & 2,57,68
+,NP,Burneatta L. Bridge,Grant,Court Of Appeals,4,TOWN OF CASTLE ROCK,48,48
+,NP,Louis Butler,Forest,Supreme Court,,TOWN OF POPPLE RIVER,3,18
 20080909__wi__primary__ward.csv,,,,,,,,
 ,LIB,Scattering,Ozaukee,State Senate,8,"CITY OF MEQUON Wards 16, 17 & 19",1,1
 ,LIB,Scattering,Marquette,State Senate,14,TOWN OF BUFFALO Wards 1 & 2,1,1
@@ -77,29 +75,29 @@ filename,party,candidate,county,office,district,ward,votes,total
 ,REP,Al Ott,Calumet,State Assembly,3,CITY OF APPLETON Ward 44,20,20
 ,REP,Don Pridemore,Washington,State Assembly,99,VILLAGE OF SLINGER Ward 9,11,11
 20081104__wi__general__ward.csv,,,,,,,,
-,,Mark D. Thibodeau,Adams,Adams County District Attorney,,TOWN OF DELL PRAIRIE Wards 1 & 2,514,517
-,,Robert D. Zapf,Kenosha,Kenosha County District Attorney,,VILLAGE OF PLEASANT PRAIRIE Wards 8 - 11,2088,2122
-,,Darrell L. Castle Chuck Baldwin,Marathon,President,,VILLAGE OF Kronenwetter Wards 5 - 8,7,1758
-,,Dick Skare,Door,State Assembly,1,TOWN OF BAILEYS HARBOR Wards 1 & 2,473,776
-,,Chad Fradette,Shawano,State Senate,30,VILLAGE OF PULASKI Wards 4 & 7,35,68
-,,Peter Theron,Columbia,House,2,VILLAGE OF POYNETTE Wards 1 - 3,415,1222
+,DEM,Mark D. Thibodeau,Adams,Adams County District Attorney,,TOWN OF DELL PRAIRIE Wards 1 & 2,514,517
+,DEM,Robert D. Zapf,Kenosha,Kenosha County District Attorney,,VILLAGE OF PLEASANT PRAIRIE Wards 8 - 11,2088,2122
+,IND,Darrell L. Castle Chuck Baldwin,Marathon,President,,VILLAGE OF Kronenwetter Wards 5 - 8,7,1758
+,DEM,Dick Skare,Door,State Assembly,1,TOWN OF BAILEYS HARBOR Wards 1 & 2,473,776
+,REP,Chad Fradette,Shawano,State Senate,30,VILLAGE OF PULASKI Wards 4 & 7,35,68
+,REP,Peter Theron,Columbia,House,2,VILLAGE OF POYNETTE Wards 1 - 3,415,1222
 20090217__wi__primary__ward.csv,,,,,,,,
-,,Julie Genovese,Dane,"Dane County Circuit Court, Branch 13",,VILLAGE OF ROCKDALE,4,14
-,,Peter C. Rotter,Marathon,"Marathon County Circuit Court, Branch 1",,VILLAGE OF BROKAW,1,18
-,,Lowell E. Holtz,Adams,State Superintendent Of Public Instruction,,TOWN OF STRONGS PRAIRIE Wards 1 & 2,3,35
+,NP,Julie Genovese,Dane,"Dane County Circuit Court, Branch 13",,VILLAGE OF ROCKDALE,4,14
+,NP,Peter C. Rotter,Marathon,"Marathon County Circuit Court, Branch 1",,VILLAGE OF BROKAW,1,18
+,NP,Lowell E. Holtz,Adams,State Superintendent Of Public Instruction,,TOWN OF STRONGS PRAIRIE Wards 1 & 2,3,35
 20090407__wi__general__ward.csv,,,,,,,,
-,,Kitty K. Brennan,Milwaukee,Court of Appeals,1,VILLAGE OF HALES CORNERS Wards 7 - 9,235,236
-,,Michael W. Hoover,St. Croix,Court of Appeals,3,VILLAGE OF SPRING VALLEY Ward 3,1,1
-,,Tony Evers,Kenosha,State Superintendent Of Public Instruction,,VILLAGE OF PADDOCK LAKE Wards 1 - 5,239,419
-,,Randy R. Koschnick,Adams,Supreme Court,,CITY OF WISCONSIN DELLS Ward 5,1,1
-,,Gene D. Linehan,Bayfield,Bayfield County Circuit Court,,TOWN OF OULU,23,80
-,,David A. Hansher,Milwaukee,"Milwaukee County Circuit Court, Branch 42",,CITY OF MILWAUKEE Ward 208,7,7
+,NP,Kitty K. Brennan,Milwaukee,Court of Appeals,1,VILLAGE OF HALES CORNERS Wards 7 - 9,235,236
+,NP,Michael W. Hoover,St. Croix,Court of Appeals,3,VILLAGE OF SPRING VALLEY Ward 3,1,1
+,NP,Tony Evers,Kenosha,State Superintendent Of Public Instruction,,VILLAGE OF PADDOCK LAKE Wards 1 - 5,239,419
+,NP,Randy R. Koschnick,Adams,Supreme Court,,CITY OF WISCONSIN DELLS Ward 5,1,1
+,NP,Gene D. Linehan,Bayfield,Bayfield County Circuit Court,,TOWN OF OULU,23,80
+,NP,David A. Hansher,Milwaukee,"Milwaukee County Circuit Court, Branch 42",,CITY OF MILWAUKEE Ward 208,7,7
 ,,Scattering,Taylor,Taylor County Circuit Court,,CITY OF MEDFORD Wards 1 & 2,1,321
 20100216__wi__primary__ward.csv,,,,,,,,
-,,John M. O'Boyle,Pierce,Pierce County Circuit Court,,VILLAGE OF PLUM CITY,6,75
+,NP,John M. O'Boyle,Pierce,Pierce County Circuit Court,,VILLAGE OF PLUM CITY,6,75
 20100406__wi__general__ward.csv,,,,,,,,
-,,Linda M. Van De Water,Calumet,Court of Appeals,2,VILLAGE OF POTTER,8,17
-,,Edward E. Leineweber,Dane,Court of Appeals,4,TOWN OF MADISON Wards 2 - 11,50,238
+,NP,Linda M. Van De Water,Calumet,Court of Appeals,2,VILLAGE OF POTTER,8,17
+,NP,Edward E. Leineweber,Dane,Court of Appeals,4,TOWN OF MADISON Wards 2 - 11,50,238
 20100914__wi__primary__ward.csv,,,,,,,,
 ,DEM,Tim John,Polk,Governor,,VILLAGE OF FREDERIC Wards 1 & 2,5,28
 ,REP,Dan Mielke,Marathon,House,7,VILLAGE OF KRONENWETTER Wards 1 - 8,118,568
@@ -107,30 +105,30 @@ filename,party,candidate,county,office,district,ward,votes,total
 ,WIG,Ben Manski,Dane,State Assembly,77,CITY OF MIDDLETON Wards 2-4,33,33
 ,NA,James James,Adams,Governor,,TOWN OF BIG FLATS Ward 1,1,2
 20101102__wi__general__ward.csv,,,,,,,,
-,,James James & No Candidate,Kewaunee,Governor,,VILLAGE OF LUXEMBURG Wards 1 & 2,2,934
+,NA,James James & No Candidate,Kewaunee,Governor,,VILLAGE OF LUXEMBURG Wards 1 & 2,2,934
 ,,Scattering,Iron,Attorney General,,CITY OF MONTREAL Ward 1,0,157
-,,Ernest J. Pagels Jr. (Write-In),Pierce,Senate,,VILLAGE OF ELMWOOD Ward 1,9,245
-,,L. D. Rockwell,Walworth,State Senate,11,"CITY OF LAKE GENEVA Wards 3-6, 9-11, 13, 14, 16, 17, 19 - 25",376,1106
-,,Rich Zipperer,Washington,State Senate,33,"CITY OF HARTFORD Wards 12 - 15, 17, 19 - 22, 26 - 28, 30, 33 - 35, 40 & 41, 49",1251,1255
-,,Ted Zigmunt,Brown,State Assembly,2,CITY OF DE PERE Wards 15 - 17,53,143
-,,Gary Tauchen,Waupaca,State Assembly,6,VILLAGE OF EMBARRASS Ward 1,102,102
-,,Richard J. Spanbauer,Fond Du Lac,State Assembly,53,CITY OF FOND DU LAC Ward 39,0,0
-,,Samantha Kerkman,Kenosha,State Assembly,66,CITY OF KENOSHA Ward 58,1,2
-,,Scott Suder,Taylor,State Assembly,69,TOWN OF TAFT Ward 1,46,47
-,,Don Pridemore,Dodge,State Assembly,99,CITY OF HARTFORD Ward 16,0,0
+,REP,Ernest J. Pagels Jr. (Write-In),Pierce,Senate,,VILLAGE OF ELMWOOD Ward 1,9,245
+,DEM,L. D. Rockwell,Walworth,State Senate,11,"CITY OF LAKE GENEVA Wards 3-6, 9-11, 13, 14, 16, 17, 19 - 25",376,1106
+,REP,Rich Zipperer,Washington,State Senate,33,"CITY OF HARTFORD Wards 12 - 15, 17, 19 - 22, 26 - 28, 30, 33 - 35, 40 & 41, 49",1251,1255
+,DEM,Ted Zigmunt,Brown,State Assembly,2,CITY OF DE PERE Wards 15 - 17,53,143
+,REP,Gary Tauchen,Waupaca,State Assembly,6,VILLAGE OF EMBARRASS Ward 1,102,102
+,REP,Richard J. Spanbauer,Fond Du Lac,State Assembly,53,CITY OF FOND DU LAC Ward 39,0,0
+,REP,Samantha Kerkman,Kenosha,State Assembly,66,CITY OF KENOSHA Ward 58,1,2
+,REP,Scott Suder,Taylor,State Assembly,69,TOWN OF TAFT Ward 1,46,47
+,REP,Don Pridemore,Dodge,State Assembly,99,CITY OF HARTFORD Ward 16,0,0
 20110215__wi__primary__ward.csv,,,,,,,,
-,,JOEL WINNIG,Door,Supreme Court,,TOWN OF GIBRALTAR Wards 1 & 2,6,102
-,,DANIEL P. STEFFEN,Polk,"POLK COUNTY CIRCUIT COURT, BRANCH 2",,TOWN OF WEST SWEDEN Wards 1 & 2,13,25
+,NP,JOEL WINNIG,Door,Supreme Court,,TOWN OF GIBRALTAR Wards 1 & 2,6,102
+,NP,DANIEL P. STEFFEN,Polk,"POLK COUNTY CIRCUIT COURT, BRANCH 2",,TOWN OF WEST SWEDEN Wards 1 & 2,13,25
 20110405__wi__general__ward.csv,,,,,,,,
-,,"David T. Prosser, Jr.",Manitowoc,Supreme Court,,"CITY OF MANITOWOC Wards 17, 18, 22, 24 - 26, 28 - 30, 32, 34 & 36",306,555
-,,Joanne F. Kloppenburg,Racine,Supreme Court,,TOWN OF WATERFORD Wards 1 - 10,573,2183
-,,SANDRA J. MARCUS,Marathon,"MARATHON COUNTY CIRCUIT COURT, BRANCH 5",,VILLAGE OF BIRNAMWOOD Ward 2,5,5
-,,GUY DUTCHER,Waushara,WAUSHARA COUNTY CIRCUIT COURT,,TOWN OF POY SIPPI Ward 1,170,170
-,,PAUL B. HIGGINBOTHAM,Jackson,Court of Appeals,4,VILLAGE OF HIXTON Ward 1,93,93
+,NP,"David T. Prosser, Jr.",Manitowoc,Supreme Court,,"CITY OF MANITOWOC Wards 17, 18, 22, 24 - 26, 28 - 30, 32, 34 & 36",306,555
+,NP,Joanne F. Kloppenburg,Racine,Supreme Court,,TOWN OF WATERFORD Wards 1 - 10,573,2183
+,NP,SANDRA J. MARCUS,Marathon,"MARATHON COUNTY CIRCUIT COURT, BRANCH 5",,VILLAGE OF BIRNAMWOOD Ward 2,5,5
+,NP,GUY DUTCHER,Waushara,WAUSHARA COUNTY CIRCUIT COURT,,TOWN OF POY SIPPI Ward 1,170,170
+,NP,PAUL B. HIGGINBOTHAM,Jackson,Court of Appeals,4,VILLAGE OF HIXTON Ward 1,93,93
 20110503__wi__special__general__ward.csv,,,,,,,,
-,,RICK AARON,OZAUKEE,State Assembly,60,"TOWN OF GRAFTON WARDS 1 2, & 6",69,422
-,,DUEY STROEBEL,WASHINGTON,State Assembly,60,TOWN OF TRENTON WDS-1.2.5.6.7,316,375
-,,ANDREW ALLEN BERG (WRITE IN),RACINE,State Assembly,83,VILLAGE OF WATERFORD Wards 1 - 7,9,900
+,DEM,RICK AARON,OZAUKEE,State Assembly,60,"TOWN OF GRAFTON WARDS 1 2, & 6",69,422
+,REP,DUEY STROEBEL,WASHINGTON,State Assembly,60,TOWN OF TRENTON WDS-1.2.5.6.7,316,375
+,DEM,ANDREW ALLEN BERG (WRITE IN),RACINE,State Assembly,83,VILLAGE OF WATERFORD Wards 1 - 7,9,900
 20110712__wi__primary-recall__ward.csv,,,,,,,,
 ,DEM,OTTO C. JUNKERMANN,Waupaca,State Senate,2,VILLAGE OF EMBARRASS Ward 1,24,42
 ,DEM,SCATTERING,Washington,State Senate,8,"VILLAGE OF GERMANTOWN Wards 1, 7, 15 - 17",19,1019
@@ -141,54 +139,54 @@ filename,party,candidate,county,office,district,ward,votes,total
 20110712__wi__special__primary__ward.csv,,,,,,,,
 ,DEM,DAVE DE FELICE,Dane,State Assembly,48,VILLAGE OF MCFARLAND wards1-7,61,1007
 20110719__wi__general-recall__ward.csv,,,,,,,,
-,,DAVID VANDERLEEST,Marinette,State Senate,30,CITY OF PESHTIGO Wards 1 - 8,180,572
+,REP,DAVID VANDERLEEST,Marinette,State Senate,30,CITY OF PESHTIGO Wards 1 - 8,180,572
 20110719__wi__primary-recall__ward.csv,,,,,,,,
 ,REP,KIM SIMAC,Forest,State Senate,12,TOWN OF LINCOLN Town of Lincoln,66,117
 ,REP,JONATHAN STEITZ,Racine,State Senate,22,CITY OF BURLINGTON Wards 9 - 16,247,452
 20110809__wi__general-recall__ward.csv,,,,,,,,
-,,ROBERT L. COWLES,Brown,State Senate,2,CITY OF DE PERE District 1 Ward 1-3,1057,2016
-,,NANCY J. NUSBAUM,Outagamie,State Senate,2,VILLAGE OF SHIOCTON Village of Shiocton,86,180
-,,SANDRA K. PASCH,Washington,State Senate,8,CITY OF MILWAUKEE Ward 262,0,0
-,,SHEILA E. HARSDORF,Burnett,State Senate,10,TOWN OF LINCOLN Lincoln Town,60,108
+,REP,ROBERT L. COWLES,Brown,State Senate,2,CITY OF DE PERE District 1 Ward 1-3,1057,2016
+,DEM,NANCY J. NUSBAUM,Outagamie,State Senate,2,VILLAGE OF SHIOCTON Village of Shiocton,86,180
+,REP,SANDRA K. PASCH,Washington,State Senate,8,CITY OF MILWAUKEE Ward 262,0,0
+,REP,SHEILA E. HARSDORF,Burnett,State Senate,10,TOWN OF LINCOLN Lincoln Town,60,108
 ,,Scattering,Shawano,State Senate,14,CITY OF MARION Wards 4 - 6,0,5
-,,JESSICA KING,Winnebago,State Senate,18,CITY OF OMRO Wards 1 - 7,598,1104
-,,DAN KAPANKE,Vernon,State Senate,32,"CITY OF WESTBY City of Westby, Ward 1-5",319,825
+,DEM,JESSICA KING,Winnebago,State Senate,18,CITY OF OMRO Wards 1 - 7,598,1104
+,REP,DAN KAPANKE,Vernon,State Senate,32,"CITY OF WESTBY City of Westby, Ward 1-5",319,825
 20110809__wi__special__general__ward.csv,,,,,,,,
-,,Chris Taylor,Dane,State Assembly,48,VILLAGE OF MCFARLAND wards1-7,486,589
+,DEM,Chris Taylor,Dane,State Assembly,48,VILLAGE OF MCFARLAND wards1-7,486,589
 20110816__wi__general-recall__ward.csv,,,,,,,,
-,,JIM HOLPERIN,Oconto,State Senate,12,TOWN OF TOWNSEND Ward 1,195,381
+,DEM,JIM HOLPERIN,Oconto,State Senate,12,TOWN OF TOWNSEND Ward 1,195,381
 ,,Scattering,Oneida,State Senate,12,TOWN OF NEWBOLD Wards 1 - 2 - 3 - 5,2,1132
-,,BRIAN HARWOOD (WRITE-IN),Kenosha,State Senate,22,TOWN OF SALEM Wards 1-15,2,2687
+,IND,BRIAN HARWOOD (WRITE-IN),Kenosha,State Senate,22,TOWN OF SALEM Wards 1-15,2,2687
 20111011__wi__special__primary__ward.csv,,,,,,,,
 ,REP,David A. Drewes,La Crosse,State Assembly,95,TOWN OF CAMPBELL Town of Campbell - Ward 7,0,0
 20111108__wi__special__general__ward.csv,,,,,,,,
-,,David A. Drewes,La Crosse,State Assembly,95,CITY OF LA CROSSE Ward 15,161,573
+,REP,David A. Drewes,La Crosse,State Assembly,95,CITY OF LA CROSSE Ward 15,161,573
 20120221__wi__primary__ward.csv,,,,,,,,
-,,Francis X. Sullivan,Dane,"DANE COUNTY CIRCUIT COURT, BRANCH 11",,TOWN OF YORK Ward 1,6,31
-,,Edward Richard Antaramian,Kenosha,"KENOSHA COUNTY CIRCUIT COURT, BRANCH 2",,TOWN OF SOMERS Wards 10-11-13,62,274
-,,"Nelson Wesley Phillips, III",Milwaukee,"MILWAUKEE COUNTY CIRCUIT COURT, BRANCH 17",,"VILLAGE OF WEST MILWAUKEE WARDS - 1, 2 & 5",26,96
-,,"Christopher R. Lipscomb, Sr.",Milwaukee,"MILWAUKEE COUNTY CIRCUIT COURT, BRANCH 17",,CITY OF ST. FRANCIS Wards 9 - 12,140,395
-,,John F. O'Melia,Oneida,"ONEIDA COUNTY CIRCUIT COURT, BRANCH 2",,TOWN OF PINE LAKE Wards 1 and 4,98,272
+,NP,Francis X. Sullivan,Dane,"DANE COUNTY CIRCUIT COURT, BRANCH 11",,TOWN OF YORK Ward 1,6,31
+,NP,Edward Richard Antaramian,Kenosha,"KENOSHA COUNTY CIRCUIT COURT, BRANCH 2",,TOWN OF SOMERS Wards 10-11-13,62,274
+,NP,"Nelson Wesley Phillips, III",Milwaukee,"MILWAUKEE COUNTY CIRCUIT COURT, BRANCH 17",,"VILLAGE OF WEST MILWAUKEE WARDS - 1, 2 & 5",26,96
+,NP,"Christopher R. Lipscomb, Sr.",Milwaukee,"MILWAUKEE COUNTY CIRCUIT COURT, BRANCH 17",,CITY OF ST. FRANCIS Wards 9 - 12,140,395
+,NP,John F. O'Melia,Oneida,"ONEIDA COUNTY CIRCUIT COURT, BRANCH 2",,TOWN OF PINE LAKE Wards 1 and 4,98,272
 20120403__wi__primary__ward.csv,,,,,,,,
 ,REP,MICHELE BACHMANN,ADAMS,President,,TOWN OF QUINCY Ward 1,4,151
 ,DEM,UNINSTRUCTED DELEGATION,WASHBURN,President,,Town of Gull Lake Ward 1,6,20
 20120403__wi__primary__ward.csv,,,,,,,,
-,,JOHN C. ALBERT,DANE,"DANE COUNTY CIRCUIT COURT, BRANCH 3",,TOWN OF OREGON WARDS 1-4,583,584
-,,THOMAS J. GRITTON,WINNEBAGO,"WINNEBAGO COUNTY CIRCUIT COURT, BRANCH 1",,CITY OF OSHKOSH D8 W15,359,361
+,NP,JOHN C. ALBERT,DANE,"DANE COUNTY CIRCUIT COURT, BRANCH 3",,TOWN OF OREGON WARDS 1-4,583,584
+,NP,THOMAS J. GRITTON,WINNEBAGO,"WINNEBAGO COUNTY CIRCUIT COURT, BRANCH 1",,CITY OF OSHKOSH D8 W15,359,361
 ,,SCATTERING,WINNEBAGO,COURT OF APPEALS,2,"TOWN OF ALGOMA Wards 1-2, 7-10",4,791
-,,ROBERT E. EATON,ASHLAND,ASHLAND COUNTY CIRCUIT COURT,,VILLAGE OF BUTTERNUT Wards 1 & 2,69,69
-,,JAMES JUDGE DUVALL,PEPIN,BUFFALO-PEPIN COUNTY CIRCUIT COURT,,CITY OF DURAND Wards 1 - 3,434,434
-,,"NELSON WESLEY PHILLIPS, III",MILWAUKEE,"MILWAUKEE COUNTY CIRCUIT COURT, BRANCH 17",,VILLAGE OF BAYSIDE Ward 1s & 3s Congress 6,6,16
-,,"NICHOLAS J. BRAZEAU, JR.",WOOD,"WOOD COUNTY CIRCUIT COURT, BRANCH 2",,CITY OF WISCONSIN RAPIDS Ward 23,67,69
+,NP,ROBERT E. EATON,ASHLAND,ASHLAND COUNTY CIRCUIT COURT,,VILLAGE OF BUTTERNUT Wards 1 & 2,69,69
+,NP,JAMES JUDGE DUVALL,PEPIN,BUFFALO-PEPIN COUNTY CIRCUIT COURT,,CITY OF DURAND Wards 1 - 3,434,434
+,NP,"NELSON WESLEY PHILLIPS, III",MILWAUKEE,"MILWAUKEE COUNTY CIRCUIT COURT, BRANCH 17",,VILLAGE OF BAYSIDE Ward 1s & 3s Congress 6,6,16
+,NP,"NICHOLAS J. BRAZEAU, JR.",WOOD,"WOOD COUNTY CIRCUIT COURT, BRANCH 2",,CITY OF WISCONSIN RAPIDS Ward 23,67,69
 20120508__wi__primary-recall__ward.csv,,,,,,,,
 ,REP,Patrick J. O'Brien (Write-In),Monroe,Governor,,"TOWN OF LA GRANGE WARDS 1A, 1B, 2A, 2B, 3A, 3B",0,233
 ,DEM,Tamra Varebrook,Racine,State Senate,21,"VILLAGE OF MOUNT PLEASANT WARDS 10,11,12,15",390,1256
 20120605__wi__general-recall__ward.csv,,,,,,,,
-,,Hari Trivedi,Adams,Governor,,Town of Adams Wards 1-3,6,525
+,IND,Hari Trivedi,Adams,Governor,,Town of Adams Wards 1-3,6,525
 ,,Scattering,Wood,Governor,,City of Wisconsin Rapids Wards 16 -23 & 25,3,2221
-,,Rebecca Kleefisch,St. Croix,Lieutenant Governor,,City of Hudson Wards 1 & 2,324,579
-,,Van H. Wanggaard,Racine,State Senate,21,"Village of Mount Pleasant Wards 19,21,22,23",1321,2523
-,,Donna Seidel,Taylor,State Senate,29,City of Medford Wards 1-8,588,1638
+,REP,Rebecca Kleefisch,St. Croix,Lieutenant Governor,,City of Hudson Wards 1 & 2,324,579
+,REP,Van H. Wanggaard,Racine,State Senate,21,"Village of Mount Pleasant Wards 19,21,22,23",1321,2523
+,DEM,Donna Seidel,Taylor,State Senate,29,City of Medford Wards 1-8,588,1638
 20120814__wi__primary__ward.csv,,,,,,,,
 ,DEM,Mario R. Hall,Milwaukee,State Assembly,12,City Of Wauwatosa Ward 24,7,104
 ,REP,Al Ott,Outagamie,State Assembly,3,Village of Combined Locks Wards 1-4,263,368
@@ -205,40 +203,40 @@ filename,party,candidate,county,office,district,ward,votes,total
 ,DEM,Scattering,Waukesha,State Senate,33,"TOWN OF DELAFIELD WARDS 1, 2, 5, 6",33,33
 ,AME,Scattering,Waukesha,State Senate,33,CITY OF WAUKESHA Ward 9,2,2
 20121204__wi__special__general__ward.csv,,,,,,,,
-,,Paul Farrow,Waukesha,State Senate,33,City of Pewaukee Wards 8-10,274,281
+,REP,Paul Farrow,Waukesha,State Senate,33,City of Pewaukee Wards 8-10,274,281
 20130219__wi__primary__ward.csv,,,,,,,,
-,,Vince Megna,Grant,Supreme Court,,"TOWN OF SOUTH LANCASTER WARDS 1, 2 & 3",3,19
-,,Janet Claire Protasiewicz,Milwaukee,"Milwaukee County Circuit Court, Branch 45",,CITY OF MILWAUKEE WARD 001,32,140
+,NP,Vince Megna,Grant,Supreme Court,,"TOWN OF SOUTH LANCASTER WARDS 1, 2 & 3",3,19
+,NP,Janet Claire Protasiewicz,Milwaukee,"Milwaukee County Circuit Court, Branch 45",,CITY OF MILWAUKEE WARD 001,32,140
 20130219__wi__special__primary__ward.csv,,,,,,,,
 ,REP,Matt Morzy,Waukesha,State Assembly,98,City of Waukesha Ward 4,6,70
 ,REP,Adam Neylon,Waukesha,State Assembly,98,City of Pewaukee Wards 5-7,219,559
 ,REP,Jeanne Tarantino,Waukesha,State Assembly,98,TOWN OF LISBON WARD 3,11,132
 20130402__wi__general__ward.csv,,,,,,,,
-,,Tony Evers,Adams,State Superintendent Of Public Instruction,,Town Of Monroe Ward 1,53,94
-,,Tony Evers,Columbia,State Superintendent Of Public Instruction,,City Of Wisconsin Dells Ward 1,54,74
-,,Don Pridemore,Dane,State Superintendent Of Public Instruction,,City Of Madison Ward 49,12,82
-,,Don Pridemore,Wood,State Superintendent Of Public Instruction,,Town Of Seneca Wards 1 -3,55,136
-,,Daniel T. Dillon,Rock,"Rock County Circuit Court, Branch 4",,CITY OF BRODHEAD WARDS 7-8,6,6
-,,Lisa K. Stark,Ashland,Court of Appeals,3,TOWN OF SHANAGOLDEN Wards 1,22,22
-,,Ed Fallone,Langlade,Supreme Court,,TOWN OF AINSWORTH WARD 1,30,100
+,NP,Tony Evers,Adams,State Superintendent Of Public Instruction,,Town Of Monroe Ward 1,53,94
+,NP,Tony Evers,Columbia,State Superintendent Of Public Instruction,,City Of Wisconsin Dells Ward 1,54,74
+,NP,Don Pridemore,Dane,State Superintendent Of Public Instruction,,City Of Madison Ward 49,12,82
+,NP,Don Pridemore,Wood,State Superintendent Of Public Instruction,,Town Of Seneca Wards 1 -3,55,136
+,NP,Daniel T. Dillon,Rock,"Rock County Circuit Court, Branch 4",,CITY OF BRODHEAD WARDS 7-8,6,6
+,NP,Lisa K. Stark,Ashland,Court of Appeals,3,TOWN OF SHANAGOLDEN Wards 1,22,22
+,NP,Ed Fallone,Langlade,Supreme Court,,TOWN OF AINSWORTH WARD 1,30,100
 20130402__wi__special__general__ward.csv,,,,,,,,
-,,Adam Neylon,Waukesha,State Assembly,98,CITY OF WAUKESHA Ward 36,314,315
-,,Adam Neylon,Waukesha,State Assembly,98,"VILLAGE OF SUSSEX Wards 5,6,7",417,419
+,REP,Adam Neylon,Waukesha,State Assembly,98,CITY OF WAUKESHA Ward 36,314,315
+,REP,Adam Neylon,Waukesha,State Assembly,98,"VILLAGE OF SUSSEX Wards 5,6,7",417,419
 20131022__wi__special__primary__ward.csv,,,,,,,,
 ,REP,Jason Red Arnold,Milwaukee,State Assembly,21,CITY OF SOUTH MILWAUKEE Wards 13 -16,20,325
 ,CON,Scattering,Clark,State Assembly,69,VILLAGE OF CURTISS WARD 1,2,2
 20131119__wi__special__primary__ward.csv,,,,,,,,
-,,Stephanie Mares,Milwaukee,State Assembly,82,Village of Greendale Wards 9-10,132,231
+,REP,Stephanie Mares,Milwaukee,State Assembly,82,Village of Greendale Wards 9-10,132,231
 20131119__wi__special__general__ward.csv,,,,,,,,
-,,Jessie Rodriguez,Milwaukee,State Assembly,21,CITY OF FRANKLIN City of Franklin - Ward 15B,56,92
-,,Tim Swiggum,Wood,State Assembly,69,"CITY OF MARSHFIELD Wards 1-4, 10, 11, 13, 14",62,1198
+,REP,Jessie Rodriguez,Milwaukee,State Assembly,21,CITY OF FRANKLIN City of Franklin - Ward 15B,56,92
+,IND,Tim Swiggum,Wood,State Assembly,69,"CITY OF MARSHFIELD Wards 1-4, 10, 11, 13, 14",62,1198
 20131217__wi__special__general__ward.csv,,,,,,,,
-,,John R. Hermes,Milwaukee,State Assembly,82,City of Greenfield Ward 20,86,223
+,DEM,John R. Hermes,Milwaukee,State Assembly,82,City of Greenfield Ward 20,86,223
 20140218__wi__primary__ward.csv,,,,,,,,
-,,Roger M. Hillestad,Dunn,"Dunn County Circuit Court, Branch 1",,TOWN OF RED CEDAR WARD 1-3,11,71
+,NP,Roger M. Hillestad,Dunn,"Dunn County Circuit Court, Branch 1",,TOWN OF RED CEDAR WARD 1-3,11,71
 20140401__wi__general__ward.csv,,,,,,,,
-,,Gary E. Sherman,Waupaca,Court of Appeals,4,TOWN OF HELVETIA Wards 1 & 2,44,44
-,,"Robert A. Kennedy, Jr.",Florence,Florence-Forest County Circuit Court,,TOWN OF FENCE WARD 1,24,46
+,NP,Gary E. Sherman,Waupaca,Court of Appeals,4,TOWN OF HELVETIA Wards 1 & 2,44,44
+,NP,"Robert A. Kennedy, Jr.",Florence,Florence-Forest County Circuit Court,,TOWN OF FENCE WARD 1,24,46
 20140812__wi__primary__ward.csv,,,,,,,,
 ,DEM,Mary Burke,Brown,Governor,,Town of Holland Wards 1 - 2,41,49
 ,CON,Jerry Broitzman,Dane,Secretary Of State,,City of Madison Ward 38,3,3
@@ -252,48 +250,48 @@ filename,party,candidate,county,office,district,ward,votes,total
 ,DEM,Scattering,Fond Du Lac,State Assembly,59,VILLAGE OF KEWASKUM WD 6,0,0
 ,REP,Adam Jarchow,Polk,State Assembly,28,VILLAGE OF BALSAM LAKE Wards 1-2,37,37
 20141104__wi__general__ward.csv,,,,,,,,
-,,Mary Burke & John Lehman,Adams,Governor,,Town of Adams Wards 1-3,233,500
-,,Steve R. Evans (Write-In),Dane,Governor,,"City of Verona Wards 1, 5",0,1037
-,,Chris Kapenga,Waukesha,State Assembly,99,"Village of Summit Wards 2,3,4,5",1227,1643
-,,Peter Flesch,Vernon,State Assembly,96,City of Westby Wards 1 - 5,375,837
-,,Dean P. Debroux,Outagamie,State Senate,1,City of Appleton Ward 59,1,1
-,,Lawrence Dale,Wood,House,7,City of Pittsville Ward 1,7,356
-,,Jerry Shidell,Ashland,State Treasurer,,City of Mellen Ward 1,3,221
+,DEM,Mary Burke & John Lehman,Adams,Governor,,Town of Adams Wards 1-3,233,500
+,REP,Steve R. Evans (Write-In),Dane,Governor,,"City of Verona Wards 1, 5",0,1037
+,REP,Chris Kapenga,Waukesha,State Assembly,99,"Village of Summit Wards 2,3,4,5",1227,1643
+,DEM,Peter Flesch,Vernon,State Assembly,96,City of Westby Wards 1 - 5,375,837
+,DEM,Dean P. Debroux,Outagamie,State Senate,1,City of Appleton Ward 59,1,1
+,IND,Lawrence Dale,Wood,House,7,City of Pittsville Ward 1,7,356
+,IND,Jerry Shidell,Ashland,State Treasurer,,City of Mellen Ward 1,3,221
 20150217__wi__special__primary__ward.csv,,,,,,,,
 ,REP,Lee E. Schlenvogt,Calumet,State Senate,20,TOWN OF BROTHERTOWN Ward 1-2,12,50
 ,DEM,Nicholas J. Stamates (Write-in),Sheboygan,State Senate,20,VILLAGE OF WALDO Ward 1,0,0
 ,CON,Scattering,Fond du Lac,State Senate,20,VILLAGE OF KEWASKUM WD 6,0,0
 20150217__wi__special__primary__ward.csv,,,,,,,,
-,,Michelle Greendeer (write-in),Jackson,Jackson County Circuit Court,,TOWN OF KOMENSKY Ward 1,45,64
-,,Candice C. M. Tlustosch,La Crosse,"La Crosse County Circuit Court, Branch 5",,VILLAGE OF WEST SALEM Wards 1-6,139,289
-,,Guy M. Taylor,Lafayette,Lafayette County Circuit Court,,CITY OF CUBA CITY Ward 5,1,7
-,,Catherine Q. Delahunt,Sheboygan,"Sheboygan County Circuit Court, Branch 4",,VILLAGE OF RANDOM LAKE Wards 1 - 2,93,245
+,NP,Michelle Greendeer (write-in),Jackson,Jackson County Circuit Court,,TOWN OF KOMENSKY Ward 1,45,64
+,NP,Candice C. M. Tlustosch,La Crosse,"La Crosse County Circuit Court, Branch 5",,VILLAGE OF WEST SALEM Wards 1-6,139,289
+,NP,Guy M. Taylor,Lafayette,Lafayette County Circuit Court,,CITY OF CUBA CITY Ward 5,1,7
+,NP,Catherine Q. Delahunt,Sheboygan,"Sheboygan County Circuit Court, Branch 4",,VILLAGE OF RANDOM LAKE Wards 1 - 2,93,245
 20150407__wi__general__ward.csv,,,,,,,,
-,,Kristina M. Bourget,Marathon,Court Of Appeals,3,VILLAGE OF KRONENWETTER Wards 6-10,92,364
+,NP,Kristina M. Bourget,Marathon,Court Of Appeals,3,VILLAGE OF KRONENWETTER Wards 6-10,92,364
 20150407__wi__special__general__ward.csv,,,,,,,,
-,,Nicholas J. Stamates (Write-in),Ozaukee,State Senate,20,VILLAGE OF SAUKVILLE Wards 1; 6-7,0,319
+,DEM,Nicholas J. Stamates (Write-in),Ozaukee,State Senate,20,VILLAGE OF SAUKVILLE Wards 1; 6-7,0,319
 20150623__wi__special__primary__ward.csv,,,,,,,,
-,,Sherryll Shaddock,Waukesha,State Senate,33,City of Waukesha Ward 38,19,19
+,DEM,Sherryll Shaddock,Waukesha,State Senate,33,City of Waukesha Ward 38,19,19
 20150721__wi__special__general__ward.csv,,,,,,,,
-,,Sherryll Shaddock,Waukesha,State Senate,33,"TOWN OF WAUKESHA Wards 1,2,3,4,5,6 & 8",128,433
+,DEM,Sherryll Shaddock,Waukesha,State Senate,33,"TOWN OF WAUKESHA Wards 1,2,3,4,5,6 & 8",128,433
 20150901__wi__special__primary__ward.csv,,,,,,,,
 ,REP,Scattering,Waukesha,State Assembly,99,Village of Oconomowoc Lake Ward 1,0,28
 ,REP,Spencer Zimmerman,Waukesha,State Assembly,99,"Town of Genesee Wards 1-5, 9 10",9,278
 20150929__wi__special__general__ward.csv,,,,,,,,
-,,Cindi Duchow,Waukesha,State Assembly,99,Village of Hartland Wards 1-13,117,140
-,,Thomas D. Hibbard (Write-In),Waukesha,State Assembly,99,Village of Wales Wards 1-4,10,106
+,REP,Cindi Duchow,Waukesha,State Assembly,99,Village of Hartland Wards 1-13,117,140
+,DEM,Thomas D. Hibbard (Write-In),Waukesha,State Assembly,99,Village of Wales Wards 1-4,10,106
 ,,Scattering,Waukesha,State Assembly,99,City of Delafield Wards 1 - 14,18,217
 20160216__wi__primary__ward.csv,,,,,,,,
-,,JoAnne F. Kloppenburg,Vilas,Supreme Court,,TOWN OF LAND O-LAKES Ward 1,81,196
-,,Larry Nelson,Iowa,Iowa County Circuit Court,,VILLAGE OF BLANCHARDVILLE Ward 2,6,14
-,,Daniel S. Johnson,Walworth,"Walworth County Circuit Court, Branch 2",,TOWN OF LINN Ward 5,11,42
-,,Trish Baker,Portage,"Portage County Circuit Court, Branch 2",,TOWN OF ALBAN Ward 1,40,107
+,NP,JoAnne F. Kloppenburg,Vilas,Supreme Court,,TOWN OF LAND O-LAKES Ward 1,81,196
+,NP,Larry Nelson,Iowa,Iowa County Circuit Court,,VILLAGE OF BLANCHARDVILLE Ward 2,6,14
+,NP,Daniel S. Johnson,Walworth,"Walworth County Circuit Court, Branch 2",,TOWN OF LINN Ward 5,11,42
+,NP,Trish Baker,Portage,"Portage County Circuit Court, Branch 2",,TOWN OF ALBAN Ward 1,40,107
 20160405__wi__primary__ward.csv,,,,,,,,
 ,DEM,Uninstructed Delegation,Milwaukee,President,,CITY OF SOUTH MILWAUKEE Ward 13-16,1,867
 20160405__wi__general__ward.csv,,,,,,,,
-,,Paul F. Reilly,Sheboygan,Court of Appeals,2,VILLAGE OF RANDOM LAKE Wards 1-2,494,496
-,,Barbara Hart Key,Winnebago,"Winnebago County Circuit Court, Branch 3",,"CITY OF MENASHA Wards 5-6,8-9,23-29,31-35,38",449,452
-,,Rebecca G. Bradley,Chippewa,Supreme Court,,TOWN OF GOETZ Ward 3,4,4
+,NP,Paul F. Reilly,Sheboygan,Court of Appeals,2,VILLAGE OF RANDOM LAKE Wards 1-2,494,496
+,NP,Barbara Hart Key,Winnebago,"Winnebago County Circuit Court, Branch 3",,"CITY OF MENASHA Wards 5-6,8-9,23-29,31-35,38",449,452
+,NP,Rebecca G. Bradley,Chippewa,Supreme Court,,TOWN OF GOETZ Ward 3,4,4
 20160809__wi__primary__ward.csv,,,,,,,,
 ,REP,Nicholas Bolz,Calumet,Calumet County District Attorney,,CITY OF CHILTON Ward 1-5,168,478
 ,LIB,John Arndt,Washington,House,5,"VILLAGE OF GERMANTOWN Wards 1,8,10-11",5,5
@@ -301,22 +299,22 @@ filename,party,candidate,county,office,district,ward,votes,total
 ,DEM,Jared William Landry,Monroe,State Senate,32,TOWN OF ADRIAN Ward 1,3,32
 ,REP,Christopher Schaefer,Outagamie,State Assembly,3,"VILLAGE OF LITTLE CHUTE Wards 3,9-11",47,244
 20161108__wi__general__ward.csv,,,,,,,,
-,,Darrell L. Castle & Scott N. Bradley,Burnett,President,,TOWN OF WOOD RIVER Ward 1-3,10,517
-,,Ron Johnson,Wood,Senate,,TOWN OF GRAND RAPIDS Ward 1-11,2573,4505
-,,Sarah Lloyd,Dodge,House,6,CITY OF MAYVILLE Wards 1-8,781,2524
-,,Fred A. Risser,Dane,State Senate,26,CITY OF MIDDLETON Wards 19-20,0,0
-,,Cindi Duchow,Waukesha,State Assembly,99,TOWN OF OTTAWA Wards 1-5,1912,1938
+,CON,Darrell L. Castle & Scott N. Bradley,Burnett,President,,TOWN OF WOOD RIVER Ward 1-3,10,517
+,REP,Ron Johnson,Wood,Senate,,TOWN OF GRAND RAPIDS Ward 1-11,2573,4505
+,DEM,Sarah Lloyd,Dodge,House,6,CITY OF MAYVILLE Wards 1-8,781,2524
+,DEM,Fred A. Risser,Dane,State Senate,26,CITY OF MIDDLETON Wards 19-20,0,0
+,REP,Cindi Duchow,Waukesha,State Assembly,99,TOWN OF OTTAWA Wards 1-5,1912,1938
 20170221__wi__primary__ward.csv,,,,,,,,
-,,John Humphries,Crawford,State Superintendent of Public Instruction,,"CITY OF PRAIRIE DU CHIEN Wards 2,7",6,55
-,,Malia Malone,Polk,"Polk County Circuit Court, Branch 1",,"VILLAGE OF TURTLE LAKE Wards 2A,2B",7,8
-,,Charles V. Feltes,Trempealeau,Trempealeau County Circuit Court,,VILLAGE OF ELEVA Ward 1,8,52
-,,Patricia Koppa,Manitowoc,"Manitowoc County Circuit Court, Branch 3",,CITY OF TWO RIVERS Wards 3-4,75,205
-,,Lowell E. Holtz,Rock,State Superintendent Of Public Instruction,,CITY OF BRODHEAD Wards 7-8,0,5
+,NP,John Humphries,Crawford,State Superintendent of Public Instruction,,"CITY OF PRAIRIE DU CHIEN Wards 2,7",6,55
+,NP,Malia Malone,Polk,"Polk County Circuit Court, Branch 1",,"VILLAGE OF TURTLE LAKE Wards 2A,2B",7,8
+,NP,Charles V. Feltes,Trempealeau,Trempealeau County Circuit Court,,VILLAGE OF ELEVA Ward 1,8,52
+,NP,Patricia Koppa,Manitowoc,"Manitowoc County Circuit Court, Branch 3",,CITY OF TWO RIVERS Wards 3-4,75,205
+,NP,Lowell E. Holtz,Rock,State Superintendent Of Public Instruction,,CITY OF BRODHEAD Wards 7-8,0,5
 20170404__wi__general__ward.csv,,,,,,,,
-,,Rick Melcher (write-in),Shawano,State Superintendent of Public Instruction,,CITY OF SHAWANO Wards 7-8,1,165
-,,Scattering,Dane,Supreme Court,,CITY OF MADISON Ward 40,184,723
-,,Brian K. Hagedorn,Ozaukee,Court of Appeals,2,TOWN OF BELGIUM Ward 1-3,113,113
-,,Guy Dutcher,Waushara,Waushara County Circuit Court,,CITY OF WAUTOMA Wards 1-3,117,117
+,NP,Rick Melcher (write-in),Shawano,State Superintendent of Public Instruction,,CITY OF SHAWANO Wards 7-8,1,165
+,NP,Scattering,Dane,Supreme Court,,CITY OF MADISON Ward 40,184,723
+,NP,Brian K. Hagedorn,Ozaukee,Court of Appeals,2,TOWN OF BELGIUM Ward 1-3,113,113
+,NP,Guy Dutcher,Waushara,Waushara County Circuit Court,,CITY OF WAUTOMA Wards 1-3,117,117
 20171219__wi__special__primary__ward.csv,,,,,,,,
 ,WGR,Scattering,St. Croix,State Senate,10,City of HUDSON Ward 11-12,1,1
 ,DEM,John Rocco Calabrese,Dunn,State Senate,10,Village of BOYCEVILLE Ward 1,8,19
@@ -324,17 +322,17 @@ filename,party,candidate,county,office,district,ward,votes,total
 ,DEM,"JOHN TATE, II",Racine,State Assembly,66,City of RACINE Ward 3,176,336
 ,REP,STEVE STANEK,Washington,State Assembly,58,City of WEST BEND Wards 4-6,107,251
 20180116__wi__special__general__ward.csv,,,,,,,,
-,,Greta Neubauer,Racine,State Assembly,66,City of RACINE Ward 3,100,100
-,,Dennis D. Degenhardt,Washington,State Assembly,58,Town of WEST BEND Wards 1-8,184,444
-,,Adam Jarchow,Pierce,State Senate,10,City of RIVER FALLS Wards 6-8,130,624
+,DEM,Greta Neubauer,Racine,State Assembly,66,City of RACINE Ward 3,100,100
+,DEM,Dennis D. Degenhardt,Washington,State Assembly,58,Town of WEST BEND Wards 1-8,184,444
+,REP,Adam Jarchow,Pierce,State Senate,10,City of RIVER FALLS Wards 6-8,130,624
 20180220__wi__primary__ward.csv,,,,,,,,
-,,Rebecca Dallet,Taylor,Supreme Court,,Town of MCKINLEY Ward 1,1,27
-,,Brenda L. Yaskal,Columbia,"Columbia County Circuit Court, Branch 3",,City of PORTAGE Ward 11,0,0
-,,Ralph Sczygelski,Manitowoc,"Manitowoc County Circuit Court, Branch 2",,"City of MANITOWOC Wards 17-18,21,23-26,28",68,245
+,NP,Rebecca Dallet,Taylor,Supreme Court,,Town of MCKINLEY Ward 1,1,27
+,NP,Brenda L. Yaskal,Columbia,"Columbia County Circuit Court, Branch 3",,City of PORTAGE Ward 11,0,0
+,NP,Ralph Sczygelski,Manitowoc,"Manitowoc County Circuit Court, Branch 2",,"City of MANITOWOC Wards 17-18,21,23-26,28",68,245
 20180403__wi__general__ward.csv,,,,,,,,
-,,Rebecca Dallet,Kewaunee,Supreme Court,,City of ALGOMA Ward 1-6,279,432
-,,Timothy G. Dugan,Milwaukee,Court of Appeals,1,Village of HALES CORNERS Wards 7-9,338,338
-,,Sandra Cardo Gorsuch,Sauk,"Sauk County Circuit Court, Branch 3",,Town of FREEDOM Ward 2,41,65
+,NP,Rebecca Dallet,Kewaunee,Supreme Court,,City of ALGOMA Ward 1-6,279,432
+,NP,Timothy G. Dugan,Milwaukee,Court of Appeals,1,Village of HALES CORNERS Wards 7-9,338,338
+,NP,Sandra Cardo Gorsuch,Sauk,"Sauk County Circuit Court, Branch 3",,Town of FREEDOM Ward 2,41,65
 20180515__wi__special__primary__ward.csv,,,,,,,,
 ,DEM,Ann Groves Lloyd,Dodge,State Assembly,42,Town of WESTFORD Wards 1-2,10,10
 ,REP,Alex Renard,Outagamie,State Senate,1,"Village of LITTLE CHUTE Wards 3,7,9-11",66,137
@@ -355,8 +353,8 @@ filename,party,candidate,county,office,district,ward,votes,total
 ,DEM,Arvina Martin,Shawano,Secretary of State,,Town of BARTELME Ward 1,66,87
 ,DEM,Dawn Marie Sass,Monroe,State Treasurer,,Village of WILTON Ward 1,17,35
 20181106__wi__general__ward.csv,,,,,,,,
-,,Bob Kulp,Marathon,State Assembly,69,Village of FENWOOD Ward 1,57,64
-,,Jay Schroeder,Washburn,Secretary Of State,,Town of FROG CREEK Ward 1,40,67
-,,"F. James Sensenbrenner, Jr.",Jefferson,House,5,Town of WATERTOWN Wards 1-2,721,1006
-,,Tammy Baldwin,Oneida,Senate,,City of RHINELANDER Wards 8-9,306,504
-,,Jerry Petrowski,Rusk,State Senate,29,Village of GLEN FLORA Ward 1,19,33
+,REP,Bob Kulp,Marathon,State Assembly,69,Village of FENWOOD Ward 1,57,64
+,REP,Jay Schroeder,Washburn,Secretary Of State,,Town of FROG CREEK Ward 1,40,67
+,REP,"F. James Sensenbrenner, Jr.",Jefferson,House,5,Town of WATERTOWN Wards 1-2,721,1006
+,DEM,Tammy Baldwin,Oneida,Senate,,City of RHINELANDER Wards 8-9,306,504
+,REP,Jerry Petrowski,Rusk,State Senate,29,Village of GLEN FLORA Ward 1,19,33


### PR DESCRIPTION
The diff is looking messy, but here's the gist:
* Party for Scattering was left blank, except for partisan primaries (in which we have Democratic Scattering, Republican Scattering, etc.).
* For non-partisan races, people candidates (i.e. not Scattering) got party "NP", except as noted in https://github.com/openelections/openelections-data-wi/issues/49.
* For partisan races, people candidates' parties were looked up in Wisconsin Elections Commission summary PDFs for the corresponding election.
* In a couple instances, we had lines with party and lines without party split out into separate blocks with the same file name. `20001107__wi__general__ward` is an example of this. Those no longer need to be separate blocks for the sake of feature test formatting, so that duplicate file heading was removed.